### PR TITLE
Gt 68

### DIFF
--- a/data_frame_enhancer.py
+++ b/data_frame_enhancer.py
@@ -149,7 +149,7 @@ class DataFrameEnhancer:
 
     def load_enhancement_job(self):
         check_temp_dir()
-        if self.version is None or self.version == 1:
+        if self.version == 1:
             if os.path.exists(f"./temp/enhanced_{self.data_key}.csv"):
                 self.data_frame = importer.import_file(f"./temp/enhanced_{self.data_key}.csv")
                 self.print_previous_enhancement()
@@ -166,7 +166,7 @@ class DataFrameEnhancer:
     def print_previous_enhancement(self):
         file_name, extension = data_key_to_file_name(self.data_key)
         print(f"{file_name}.{extension} has already been enhanced with version {self.version}.")
-        if self.version is None or self.version == 1:
+        if self.version == 1:
             print(f"Please look at output/{file_name}_enhanced.{extension} for enhanced data.")
         if self.version == 2:
             print(f"Please look at output/comprehensive_enhanced_{file_name}.xlsx for enhanced data.")
@@ -235,7 +235,7 @@ class DataFrameEnhancer:
 
     def enhance(self):
         self.load_enhancement_job()
-        if self.version is None or self.version == 1:
+        if self.version == 1:
             return self.data_frame
 
 

--- a/geocoder.py
+++ b/geocoder.py
@@ -89,7 +89,7 @@ def geocode_addresses_in_data_frame(data_frame, data_key, version=1):
     :param version: Toggles geocoding in one time frame or multiple (decades)
     :return: Data frame with new "SPATIAL_GEOID" column, to be enhanced
     """
-    if version is None or version == 1:
+    if version == 1:
         data_frame[constant.GEO_ID_NAME] = ''
         addresses_to_geocoder(data_frame, data_key, decade_dict[Decade.Ten])
         geocoded_data_frame = importer.import_file(f"./temp/geocoded_{data_key}.csv")

--- a/importer.py
+++ b/importer.py
@@ -38,6 +38,6 @@ def import_file(full_file_path, version=1):
                                                                     infer_datetime_format=True)
             input_data_frame['address_end_date'] = pd.to_datetime(input_data_frame['address_end_date'],
                                                                   infer_datetime_format=True)
-        except ValueError:
+        except KeyError:
             raise Exception(f"{full_file_path} is missing 'address_start_date' and/or 'address_end_date' columns.")
     return input_data_frame

--- a/main.py
+++ b/main.py
@@ -40,63 +40,60 @@ def data_key_to_file_name(data_key):
     return file_name, extension
 
 
-def input_file_validation(data_frame, version):
-    if version in [None, 1, 2]:
-        if constant.GEO_ID_NAME not in data_frame.columns and not (
-                'street' in data_frame.columns and
-                'city' in data_frame.columns and
-                'state' in data_frame.columns and
-                'zip' in data_frame.columns):
-            raise Exception(f"Input file has missing address columns or a missing {constant.GEO_ID_NAME} column.")
-        if constant.GEO_ID_NAME not in data_frame.columns:
-            city_missing = data_frame.index[data_frame['city'] == ''].tolist()
-            zip_missing = data_frame.index[data_frame['zip'] == ''].tolist()
-            if len(city_missing) > 0:
-                print(f"{len(city_missing)} rows are missing a city in their address at these indexes: {city_missing}")
-            if len(zip_missing) > 0:
-                print(f"{len(zip_missing)} rows are missing a zip code in their address at these indexes: {zip_missing}")
-        if version == 2:
-            address_start_date_missing = data_frame.index[data_frame['address_start_date'] == ''].tolist()
-            address_end_date_missing = data_frame.index[data_frame['address_end_date'] == ''].tolist()
-            if len(address_start_date_missing) > 0:
-                print(f"{len(address_start_date_missing)} rows are missing an address start date at these indexes: {address_start_date_missing}")
-            if len(address_end_date_missing) > 0:
-                print(f"{len(address_end_date_missing)} rows are missing an address end date at these indexes: {address_end_date_missing}")
-    else:
-        raise Exception("Invalid version number. Version can be 1 or 2 (default is 1).")
+def input_file_validation(data_frame, argument):
+    if argument.geocode:
+        if not ('street' in data_frame.columns and 'city' in data_frame.columns and
+                'state' in data_frame.columns and 'zip' in data_frame.columns):
+            raise Exception(f"Input file is missing at least one address column, (street, city, state, zip) are required.")
+        if constant.GEO_ID_NAME in data_frame.columns:
+            print(f"Warning: You have opted into geocoding, even though your input file already contains a {constant.GEO_ID_NAME} column.")
+        city_missing = data_frame.index[data_frame['city'] == ''].tolist()
+        zip_missing = data_frame.index[data_frame['zip'] == ''].tolist()
+        if len(city_missing) > 0:
+            print(f"Warning: {len(city_missing)} rows are missing a city in their address at these indexes: {city_missing}")
+        if len(zip_missing) > 0:
+            print(f"Warning: {len(zip_missing)} rows are missing a zip code in their address at these indexes: {zip_missing}")
+    elif constant.GEO_ID_NAME not in data_frame.columns:
+        raise Exception(f"Input file is missing {constant.GEO_ID_NAME} column, and you have not opted into geocoding. "
+                        f"Address census tracts are required for enhancement process.")
+    if argument.version == 2:
+        address_start_date_missing = data_frame.index[data_frame['address_start_date'] == ''].tolist()
+        address_end_date_missing = data_frame.index[data_frame['address_end_date'] == ''].tolist()
+        if len(address_start_date_missing) > 0:
+            print(f"Warning: {len(address_start_date_missing)} rows are missing an address start date at these indexes: {address_start_date_missing}")
+        if len(address_end_date_missing) > 0:
+            print(f"Warning: {len(address_end_date_missing)} rows are missing an address end date at these indexes: {address_end_date_missing}")
 
 
-def main(options):
-    if options.filename:
-        input_file_path = f'./input/{options.filename}'
-    else:
-        input_file_path = './input/addresses.xlsx'
+def main(argument):
+    input_file_path = f'./input/{argument.filename}'
 
     # Step 1: Import the data to be enhanced. Currently supports .csv, .xls, .xlsx
     # Look at supporting Oracle, MySQL, PostgreSQL, SQL Server, REDCap
     data_key = get_data_key(input_file_path)
     file_name, extension = data_key_to_file_name(data_key)
     print(f"Importing input file located at {input_file_path}")
-    input_data_frame = importer.import_file(input_file_path, options.version)
-    input_file_validation(input_data_frame, options.version)
+    input_data_frame = importer.import_file(input_file_path, argument.version)
+    input_file_validation(input_data_frame, argument)
 
     data_elements = sds.SedohDataElements().data_elements
 
     # Setup: Load data files for data sources that do not have an existing API
     print(f"Importing data files")
-    if options.version == 2:
+    if argument.version == 2:
         data_files = sds.DataFiles().data_files
     else:
         data_files = load_data_files()
 
     # Optional Step: Geocode addresses
-    if geocoder.geocodable(input_data_frame):
-        input_data_frame = geocoder.geocode_addresses_in_data_frame(input_data_frame, data_key, version=options.version)
+    if argument.geocode:
+        input_data_frame = geocoder.geocode_addresses_in_data_frame(input_data_frame, data_key,
+                                                                    version=argument.version)
 
     # Step 2: Enhance the data with the requested data elements
     print("Starting enhancement with SEDoH data")
-    sedoh_enhancer = DataFrameEnhancer(input_data_frame, data_elements, data_files, data_key, version=options.version)
-    if options.version == 2:
+    sedoh_enhancer = DataFrameEnhancer(input_data_frame, data_elements, data_files, data_key, version=argument.version)
+    if argument.version == 2:
         sedoh_enhancer.enhance()
     else:
         enhanced_data_frame = sedoh_enhancer.enhance()
@@ -109,7 +106,10 @@ def main(options):
 
 if __name__ == "__main__""":
     parser = OptionParser()
-    parser.add_option('-f', '--file', type='string', dest='filename', help='name of input file: string')
-    parser.add_option('-v', '--version', type='int', dest='version', help='version of gis-toolkit: int')
+    parser.add_option('-f', '--file', type='string', dest='filename', default='addresses.xlsx',
+                      help='name of input file: string')
+    parser.add_option('-v', '--version', type='int', dest='version', default=1, help='version of gis-toolkit: int')
+    parser.add_option('-g', '--geocode', type='choice', dest='geocode', default=None, choices=['geocode'],
+                      help='turn on geocoding, default is off')
     (options, args) = parser.parse_args()
     main(options)

--- a/main.py
+++ b/main.py
@@ -40,8 +40,8 @@ def data_key_to_file_name(data_key):
     return file_name, extension
 
 
-def input_file_validation(data_frame, argument):
-    if argument.geocode:
+def input_file_validation(data_frame, version, geocode):
+    if geocode:
         if not ('street' in data_frame.columns and 'city' in data_frame.columns and
                 'state' in data_frame.columns and 'zip' in data_frame.columns):
             raise Exception(f"Input file is missing at least one address column, (street, city, state, zip) are required.")
@@ -56,7 +56,7 @@ def input_file_validation(data_frame, argument):
     elif constant.GEO_ID_NAME not in data_frame.columns:
         raise Exception(f"Input file is missing {constant.GEO_ID_NAME} column, and you have not opted into geocoding. "
                         f"Address census tracts are required for enhancement process.")
-    if argument.version == 2:
+    if version == 2:
         address_start_date_missing = data_frame.index[data_frame['address_start_date'] == ''].tolist()
         address_end_date_missing = data_frame.index[data_frame['address_end_date'] == ''].tolist()
         if len(address_start_date_missing) > 0:
@@ -74,7 +74,7 @@ def main(argument):
     file_name, extension = data_key_to_file_name(data_key)
     print(f"Importing input file located at {input_file_path}")
     input_data_frame = importer.import_file(input_file_path, argument.version)
-    input_file_validation(input_data_frame, argument)
+    input_file_validation(input_data_frame, argument.version, argument.geocode)
 
     data_elements = sds.SedohDataElements().data_elements
 

--- a/tests/test_enhancement.py
+++ b/tests/test_enhancement.py
@@ -61,8 +61,8 @@ def test_enhancement_validity():
 
 
 def test_input_file_validation():
-    input_data_frame_v1 = importer.import_file('../tests/input_file_validation_v1.csv')
-    input_data_frame_v2 = importer.import_file('../tests/input_file_validation_v2.csv', version=2)
+    input_data_frame_v1 = importer.import_file('./tests/input_file_validation_v1.csv')
+    input_data_frame_v2 = importer.import_file('./tests/input_file_validation_v2.csv', version=2)
     try:
         main.input_file_validation(input_data_frame_v1, version=1, geocode="geocode")
     except Exception:

--- a/tests/test_enhancement.py
+++ b/tests/test_enhancement.py
@@ -61,14 +61,14 @@ def test_enhancement_validity():
 
 
 def test_input_file_validation():
-    input_data_frame_v1 = importer.import_file('./tests/input_file_validation_v1.csv')
-    input_data_frame_v2 = importer.import_file('./tests/input_file_validation_v2.csv')
+    input_data_frame_v1 = importer.import_file('../tests/input_file_validation_v1.csv')
+    input_data_frame_v2 = importer.import_file('../tests/input_file_validation_v2.csv', version=2)
     try:
-        main.input_file_validation(input_data_frame_v1, 1)
+        main.input_file_validation(input_data_frame_v1, version=1, geocode="geocode")
     except Exception:
         pytest.fail("input_file_validation() failed with version 1")
     try:
-        main.input_file_validation(input_data_frame_v2, 2)
+        main.input_file_validation(input_data_frame_v2, version=2, geocode=None)
     except Exception:
         pytest.fail("input_file_validation() failed with version 2")
 

--- a/value_getter.py
+++ b/value_getter.py
@@ -7,6 +7,7 @@ import constant
 
 load_dotenv()
 
+
 # Note on naming scheme: parameters = named variables passed to a function,
 #                        arguments = expressions used when calling the function,
 #                        options = optional arguments which allow yoy to customize the function
@@ -28,7 +29,8 @@ def get_value(data_element, arguments, data_files, version=1):
                                                  data_element.variable_name)
         elif version == 2:
             if data_element.get_strategy == GetStrategy.FILE:
-                return get_file_value(data_element.source_variable, arguments, data_files.data_frame, data_files.tract_column)
+                return get_file_value(data_element.source_variable, arguments, data_files.data_frame,
+                                      data_files.tract_column)
             elif data_element.get_strategy == GetStrategy.FILE_AND_CALCULATION:
                 return get_calculated_file_value(data_element.source_variable, arguments, data_files.data_frame,
                                                  data_files.tract_column, data_element.variable_name)
@@ -49,13 +51,14 @@ def get_acs_data_frame_value(data_frame, data_element, arguments, data_files, ve
                 source_var = data_element.source_variable[:data_element.source_variable.index(',')]
                 calc_var = data_element.source_variable[data_element.source_variable.index(',') + 1:]
                 return get_acs_calculation(data_element.variable_name,
-                                                     [data_frame.loc[arguments["fips_concatenated_code"], source_var],
-                                                      data_frame.loc[arguments["fips_concatenated_code"], calc_var]],
-                                                      arguments, data_files, version)
+                                           [data_frame.loc[arguments["fips_concatenated_code"], source_var],
+                                            data_frame.loc[arguments["fips_concatenated_code"], calc_var]],
+                                           arguments, data_files, version)
             else:
                 return get_acs_calculation(data_element.variable_name,
-                                           data_frame.loc[arguments["fips_concatenated_code"], data_element.source_variable],
-                                            arguments, data_files, version)
+                                           data_frame.loc[
+                                               arguments["fips_concatenated_code"], data_element.source_variable],
+                                           arguments, data_files, version)
         else:
             return data_frame.loc[arguments["fips_concatenated_code"], data_element.source_variable]
     else:
@@ -160,14 +163,16 @@ def get_acs_calculation(variable_name, source_value, arguments, data_files, vers
     elif variable_name == 'housing_percent_occupied_lacking_complete_kitchen':
         return str(100 - float(source_value))
     elif variable_name == 'population_density':
-        if version is None or version == 1:
+        if version == 1:
             aland = get_file_value("ALAND", arguments,
                                    data_files[SedohDataSource.Gazetteer][0],
                                    data_files[SedohDataSource.Gazetteer][1])
-        else:
+        elif version == 2:
             aland = get_file_value("ALAND", arguments,
                                    data_files[SedohDataSource.Gazetteer][1].data_frame,
                                    data_files[SedohDataSource.Gazetteer][1].tract_column)
+        else:
+            aland = constant.NOT_AVAILABLE
         if aland == constant.NOT_AVAILABLE or int(aland) == 0:
             return constant.NOT_AVAILABLE
         else:
@@ -214,7 +219,8 @@ def get_calculated_file_value(source_variables, arguments, data_file, data_file_
 def get_raster_file_value(arguments, data_file):
     latitude = round(float(arguments["latitude"]), data_file.precision)
     longitude = round(float(arguments["longitude"]), data_file.precision)
-    if data_file.latitude_range[0] <= latitude <= data_file.latitude_range[1] and data_file.longitude_range[0] <= longitude <= data_file.longitude_range[1]:
+    if data_file.latitude_range[0] <= latitude <= data_file.latitude_range[1] and data_file.longitude_range[
+        0] <= longitude <= data_file.longitude_range[1]:
         latitude_difference = round(latitude - data_file.latitude_range[0], data_file.precision)
         longitude_difference = round(longitude - data_file.longitude_range[0], data_file.precision)
         latitude_index = data_file.latitude_transform - int(round(latitude_difference / data_file.step, 2))
@@ -223,4 +229,3 @@ def get_raster_file_value(arguments, data_file):
         if value != -99:
             return value
     return constant.NOT_AVAILABLE
-


### PR DESCRIPTION
Geocoding is now turned off by default. You need to opt into geocoding when running the enhance.exe command, by including the option '-g geocode'. (ex. enhance.exe -f filename.csv -v 1 -g geocode) Omitting the geocoding option, '-g geocode', will skip the geocoding process, however it will throw an error if your input file does not include address census tracts.