### PR TITLE
Gt 69

### DIFF
--- a/constant.py
+++ b/constant.py
@@ -5,3 +5,5 @@ ADDRESS_NOT_GEOCODABLE = "Not_Found"  # Geocoder did not find a census tract mat
 DATE_COLUMN = "Date"  # Column name of census tract date in cache
 ADDRESS_START_DATE = "address_start_date"
 ADDRESS_END_DATE = "address_end_date"
+LATITUDE = "latitude"
+LONGITUDE = "longitude"

--- a/data_frame_enhancer.py
+++ b/data_frame_enhancer.py
@@ -203,14 +203,21 @@ class DataFrameEnhancer:
         data_sets = self.acs_data_source.data_element_data_set()
         file_name, extension = data_key_to_file_name(self.data_key)
         excel_path = f'./output/comprehensive_enhanced_{file_name}.xlsx'
+        if constant.LATITUDE in self.data_frame.columns and constant.LONGITUDE in self.data_frame.columns:
+            read_raster = True
+        else:
+            read_raster = False
         for data_element in self.data_elements:
             element_data_frame = data_element_data_frame(self.data_frame, data_element,
                                                          self.data_files[data_element.data_source])
             for i, data_source in enumerate(self.data_files[data_element.data_source]):
                 for index, row in element_data_frame.iterrows():
-                    arguments = {"fips_concatenated_code": element_data_frame.loc[index, constant.GEO_ID_NAME],
-                                 "latitude": element_data_frame.loc[index, "latitude"],
-                                 "longitude": element_data_frame.loc[index, "longitude"]}
+                    if read_raster:
+                        arguments = {"fips_concatenated_code": element_data_frame.loc[index, constant.GEO_ID_NAME],
+                                     constant.LATITUDE: element_data_frame.loc[index, constant.LATITUDE],
+                                     constant.LONGITUDE: element_data_frame.loc[index, constant.LONGITUDE]}
+                    else:
+                        arguments = {"fips_concatenated_code": element_data_frame.loc[index, constant.GEO_ID_NAME]}
                     if i == 0 and element_data_frame.loc[index, 'address_start_date'] < data_source.start_date:
                         element_data_frame.loc[index, 'address_start_date'] = data_source.start_date
                     if data_source.start_date <= element_data_frame.loc[

--- a/geocoder.py
+++ b/geocoder.py
@@ -72,13 +72,13 @@ def geocode_data_frame(data_frame):
 
 
 def parse_lat_long(data_frame, geocoded_data_frame):
-    data_frame['latitude'] = ''
-    data_frame['longitude'] = ''
+    data_frame[constant.LATITUDE] = ''
+    data_frame[constant.LONGITUDE] = ''
     for index, row in geocoded_data_frame.iterrows():
         if row['census_tract'] != constant.ADDRESS_NOT_GEOCODABLE:
             comma = row['latitude_longitude'].index(',')
-            data_frame.loc[index, 'longitude'] = row['latitude_longitude'][0: comma]
-            data_frame.loc[index, 'latitude'] = row['latitude_longitude'][comma + 1:]
+            data_frame.loc[index, constant.LATITUDE] = row['latitude_longitude'][0: comma]
+            data_frame.loc[index, constant.LONGITUDE] = row['latitude_longitude'][comma + 1:]
     return data_frame
 
 

--- a/main.py
+++ b/main.py
@@ -56,6 +56,10 @@ def input_file_validation(data_frame, version, geocode):
     elif constant.GEO_ID_NAME not in data_frame.columns:
         raise Exception(f"Input file is missing {constant.GEO_ID_NAME} column, and you have not opted into geocoding. "
                         f"Address census tracts are required for enhancement process.")
+    elif version == 2 and (constant.LATITUDE not in data_frame.columns or constant.LONGITUDE not in data_frame.columns):
+        print(f"Warning: {constant.LATITUDE} and/or {constant.LONGITUDE} columns are missing. Addresses will not be able"
+              f"to be enhanced with pollutant data from raster files. Raster file data is geographic and requires the"
+              f"latitude and longitude of address to be read.")
     if version == 2:
         address_start_date_missing = data_frame.index[data_frame['address_start_date'] == ''].tolist()
         address_end_date_missing = data_frame.index[data_frame['address_end_date'] == ''].tolist()

--- a/main.py
+++ b/main.py
@@ -57,8 +57,8 @@ def input_file_validation(data_frame, version, geocode):
         raise Exception(f"Input file is missing {constant.GEO_ID_NAME} column, and you have not opted into geocoding. "
                         f"Address census tracts are required for enhancement process.")
     elif version == 2 and (constant.LATITUDE not in data_frame.columns or constant.LONGITUDE not in data_frame.columns):
-        print(f"Warning: {constant.LATITUDE} and/or {constant.LONGITUDE} columns are missing. Addresses will not be able"
-              f"to be enhanced with pollutant data from raster files. Raster file data is geographic and requires the"
+        print(f"Warning: {constant.LATITUDE} and/or {constant.LONGITUDE} columns are missing. Addresses will not be able "
+              f"to be enhanced with pollutant data from raster files. Raster file data is geographic and requires the "
               f"latitude and longitude of address to be read.")
     if version == 2:
         address_start_date_missing = data_frame.index[data_frame['address_start_date'] == ''].tolist()

--- a/value_getter.py
+++ b/value_getter.py
@@ -34,7 +34,7 @@ def get_value(data_element, arguments, data_files, version=1):
             elif data_element.get_strategy == GetStrategy.FILE_AND_CALCULATION:
                 return get_calculated_file_value(data_element.source_variable, arguments, data_files.data_frame,
                                                  data_files.tract_column, data_element.variable_name)
-            elif data_element.get_strategy == GetStrategy.RASTER_FILE:
+            elif data_element.get_strategy == GetStrategy.RASTER_FILE and constant.LATITUDE in arguments.keys() and constant.LONGITUDE in arguments.keys():
                 return get_raster_file_value(arguments, data_files)
     else:
         return None
@@ -217,8 +217,8 @@ def get_calculated_file_value(source_variables, arguments, data_file, data_file_
 
 
 def get_raster_file_value(arguments, data_file):
-    latitude = round(float(arguments["latitude"]), data_file.precision)
-    longitude = round(float(arguments["longitude"]), data_file.precision)
+    latitude = round(float(arguments[constant.LATITUDE]), data_file.precision)
+    longitude = round(float(arguments[constant.LONGITUDE]), data_file.precision)
     if data_file.latitude_range[0] <= latitude <= data_file.latitude_range[1] and data_file.longitude_range[
         0] <= longitude <= data_file.longitude_range[1]:
         latitude_difference = round(latitude - data_file.latitude_range[0], data_file.precision)


### PR DESCRIPTION
Warning added for missing latitude and longitude columns in the input file should geocoding not be opted into. Version 2 enhancement can now enhance without these columns, but raster file pollutant data will not be used. Raster file data is geographic and requires the latitude and longitude of an address to be read. Constants for latitude and longitude column names are also added.